### PR TITLE
Add payment method configuration tools

### DIFF
--- a/modelcontextprotocol/src/index.ts
+++ b/modelcontextprotocol/src/index.ts
@@ -41,6 +41,8 @@ const ACCEPTED_TOOLS = [
   'subscriptions.update',
   'disputes.read',
   'disputes.update',
+  'paymentMethodConfigurations.read',
+  'paymentMethodConfigurations.update',
   'documentation.read',
 ];
 

--- a/modelcontextprotocol/src/test/index.test.ts
+++ b/modelcontextprotocol/src/test/index.test.ts
@@ -250,6 +250,10 @@ const ALL_ACTIONS = {
   paymentIntents: {
     read: true,
   },
+  paymentMethodConfigurations: {
+    read: true,
+    update: true,
+  },
   disputes: {
     read: true,
     update: true,

--- a/python/stripe_agent_toolkit/api.py
+++ b/python/stripe_agent_toolkit/api.py
@@ -25,6 +25,8 @@ from .functions import (
     create_refund,
     list_payment_intents,
     create_billing_portal_session,
+    list_payment_method_configurations,
+    update_payment_method_configuration,
 )
 
 
@@ -96,6 +98,14 @@ class StripeAPI(BaseModel):
         elif method == "list_payment_intents":
             return json.dumps(
                 list_payment_intents(self._context, *args, **kwargs)
+            )
+        elif method == "list_payment_method_configurations":
+            return json.dumps(
+                list_payment_method_configurations(self._context, *args, **kwargs)
+            )
+        elif method == "update_payment_method_configuration":
+            return json.dumps(
+                update_payment_method_configuration(self._context, *args, **kwargs)
             )
         elif method == "create_billing_portal_session":
             return json.dumps(

--- a/python/stripe_agent_toolkit/configuration.py
+++ b/python/stripe_agent_toolkit/configuration.py
@@ -12,6 +12,7 @@ Object = Literal[
     "balance",
     "refunds",
     "paymentIntents",
+    "payment_method_configurations",
 ]
 
 
@@ -39,6 +40,7 @@ class Actions(TypedDict, total=False):
     refunds: Optional[Permission]
     payment_intents: Optional[Permission]
     billing_portal_sessions: Optional[Permission]
+    payment_method_configurations: Optional[Permission]
 
 
 # Define Context type

--- a/python/stripe_agent_toolkit/functions.py
+++ b/python/stripe_agent_toolkit/functions.py
@@ -387,3 +387,37 @@ def create_billing_portal_session(context: Context, customer: str, return_url: O
         "customer": session_object.customer,
         "url": session_object.url,
     }
+
+
+def list_payment_method_configurations(
+    context: Context, limit: Optional[int] = None
+):
+    """List payment method configurations."""
+
+    params: dict = {}
+    if limit:
+        params["limit"] = limit
+    if context.get("account") is not None:
+        account = context.get("account")
+        if account is not None:
+            params["stripe_account"] = account
+
+    configs = stripe.PaymentMethodConfiguration.list(**params)
+    return [{"id": c.id} for c in configs.data]
+
+
+def update_payment_method_configuration(
+    context: Context, configuration: str, payment_method: str, enabled: bool
+):
+    """Enable or disable a payment method on a configuration."""
+
+    update_params = {
+        payment_method: {"display_preference": {"merchant_enabled": enabled}}
+    }
+    if context.get("account") is not None:
+        account = context.get("account")
+        if account is not None:
+            update_params["stripe_account"] = account
+
+    config = stripe.PaymentMethodConfiguration.update(configuration, **update_params)
+    return {"id": config.id}

--- a/python/stripe_agent_toolkit/prompts.py
+++ b/python/stripe_agent_toolkit/prompts.py
@@ -112,3 +112,19 @@ It takes two arguments:
 - customer (str): The ID of the customer to create the invoice item for.
 - return_url (str, optional): The default URL to return to afterwards.
 """
+
+LIST_PAYMENT_METHOD_CONFIGURATIONS_PROMPT = """
+This tool will fetch a list of Payment Method Configurations from Stripe.
+
+It takes one optional argument:
+- limit (int, optional): The number of configurations to return.
+"""
+
+UPDATE_PAYMENT_METHOD_CONFIGURATION_PROMPT = """
+This tool will update a payment method configuration in Stripe.
+
+It takes three arguments:
+- configuration (str): The ID of the configuration to update.
+- payment_method (str): The payment method type to modify.
+- enabled (bool): Whether the payment method should be enabled.
+"""

--- a/python/stripe_agent_toolkit/schema.py
+++ b/python/stripe_agent_toolkit/schema.py
@@ -207,3 +207,29 @@ class CreateBillingPortalSession(BaseModel):
             "The default URL to return to afterwards."
         ),
     )
+
+
+class ListPaymentMethodConfigurations(BaseModel):
+    """Schema for the ``list_payment_method_configurations`` operation."""
+
+    limit: Optional[int] = Field(
+        None,
+        description=(
+            "A limit on the number of objects to be returned."
+            " Limit can range between 1 and 100."
+        ),
+    )
+
+
+class UpdatePaymentMethodConfiguration(BaseModel):
+    """Schema for the ``update_payment_method_configuration`` operation."""
+
+    configuration: str = Field(
+        ..., description="The ID of the configuration to update."
+    )
+    payment_method: str = Field(
+        ..., description="The payment method type to modify."
+    )
+    enabled: bool = Field(
+        ..., description="Whether the payment method should be enabled."
+    )

--- a/python/stripe_agent_toolkit/tools.py
+++ b/python/stripe_agent_toolkit/tools.py
@@ -16,6 +16,8 @@ from .prompts import (
     CREATE_REFUND_PROMPT,
     LIST_PAYMENT_INTENTS_PROMPT,
     CREATE_BILLING_PORTAL_SESSION_PROMPT,
+    LIST_PAYMENT_METHOD_CONFIGURATIONS_PROMPT,
+    UPDATE_PAYMENT_METHOD_CONFIGURATION_PROMPT,
 )
 
 from .schema import (
@@ -34,6 +36,8 @@ from .schema import (
     CreateRefund,
     ListPaymentIntents,
     CreateBillingPortalSession,
+    ListPaymentMethodConfigurations,
+    UpdatePaymentMethodConfiguration,
 )
 
 tools: List[Dict] = [
@@ -199,6 +203,28 @@ tools: List[Dict] = [
         "actions": {
             "billing_portal_sessions": {
                 "create": True,
+            }
+        },
+    },
+    {
+        "method": "list_payment_method_configurations",
+        "name": "List Payment Method Configurations",
+        "description": LIST_PAYMENT_METHOD_CONFIGURATIONS_PROMPT,
+        "args_schema": ListPaymentMethodConfigurations,
+        "actions": {
+            "payment_method_configurations": {
+                "read": True,
+            }
+        },
+    },
+    {
+        "method": "update_payment_method_configuration",
+        "name": "Update Payment Method Configuration",
+        "description": UPDATE_PAYMENT_METHOD_CONFIGURATION_PROMPT,
+        "args_schema": UpdatePaymentMethodConfiguration,
+        "actions": {
+            "payment_method_configurations": {
+                "update": True,
             }
         },
     },

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -17,6 +17,8 @@ from stripe_agent_toolkit.functions import (
     create_refund,
     list_payment_intents,
     create_billing_portal_session,
+    list_payment_method_configurations,
+    update_payment_method_configuration,
 )
 
 
@@ -891,6 +893,42 @@ class TestStripeFunctions(unittest.TestCase):
                 "url": mock_billing_portal_session["url"],
                 "customer": mock_billing_portal_session["customer"],
             })
+
+    def test_list_payment_method_configurations(self):
+        with mock.patch("stripe.PaymentMethodConfiguration.list") as mock_function:
+            mock_configs = [
+                {"id": "pmc_123"},
+                {"id": "pmc_456"},
+            ]
+
+            mock_function.return_value = stripe.ListObject.construct_from(
+                {"data": [stripe.PaymentMethodConfiguration.construct_from(c, "sk") for c in mock_configs]},
+                "sk"
+            )
+
+            result = list_payment_method_configurations(context={})
+
+            mock_function.assert_called_with()
+            self.assertEqual(result, mock_configs)
+
+    def test_update_payment_method_configuration(self):
+        with mock.patch("stripe.PaymentMethodConfiguration.update") as mock_function:
+            mock_config = {"id": "pmc_123"}
+            mock_function.return_value = stripe.PaymentMethodConfiguration.construct_from(mock_config, "sk")
+
+            result = update_payment_method_configuration(
+                context={},
+                configuration="pmc_123",
+                payment_method="link",
+                enabled=True,
+            )
+
+            mock_function.assert_called_with(
+                "pmc_123",
+                link={"display_preference": {"merchant_enabled": True}},
+            )
+
+            self.assertEqual(result, {"id": mock_config["id"]})
 
 if __name__ == "__main__":
     unittest.main()

--- a/typescript/src/shared/configuration.ts
+++ b/typescript/src/shared/configuration.ts
@@ -15,6 +15,7 @@ export type Object =
   | 'refunds'
   | 'paymentIntents'
   | 'subscriptions'
+  | 'paymentMethodConfigurations'
   | 'documentation'
   | 'coupons';
 

--- a/typescript/src/shared/paymentMethodConfigurations/listPaymentMethodConfigurations.ts
+++ b/typescript/src/shared/paymentMethodConfigurations/listPaymentMethodConfigurations.ts
@@ -1,0 +1,56 @@
+import Stripe from 'stripe';
+import {z} from 'zod';
+import type {Context} from '@/shared/configuration';
+import type {Tool} from '@/shared/tools';
+
+export const listPaymentMethodConfigurationsPrompt = (_context: Context = {}) => `
+This tool will fetch a list of Payment Method Configurations from Stripe.
+
+It takes one optional argument:
+- limit (int, optional): The number of configurations to return.
+`;
+
+export const listPaymentMethodConfigurationsParameters = (_context: Context = {}) =>
+  z.object({
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'A limit on the number of objects to be returned. Limit can range between 1 and 100.'
+      ),
+  });
+
+export const listPaymentMethodConfigurations = async (
+  stripe: Stripe,
+  context: Context,
+  params: z.infer<ReturnType<typeof listPaymentMethodConfigurationsParameters>>
+) => {
+  try {
+    const configs = await stripe.paymentMethodConfigurations.list(
+      params,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
+    return configs.data;
+  } catch (error) {
+    return 'Failed to list payment method configurations';
+  }
+};
+
+const tool = (context: Context): Tool => ({
+  method: 'list_payment_method_configurations',
+  name: 'List Payment Method Configurations',
+  description: listPaymentMethodConfigurationsPrompt(context),
+  parameters: listPaymentMethodConfigurationsParameters(context),
+  actions: {
+    paymentMethodConfigurations: {
+      read: true,
+    },
+  },
+  execute: listPaymentMethodConfigurations,
+});
+
+export default tool;

--- a/typescript/src/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration.ts
+++ b/typescript/src/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration.ts
@@ -1,0 +1,59 @@
+import Stripe from 'stripe';
+import {z} from 'zod';
+import type {Context} from '@/shared/configuration';
+import type {Tool} from '@/shared/tools';
+
+export const updatePaymentMethodConfigurationPrompt = (_context: Context = {}) => `
+This tool will update a payment method configuration in Stripe.
+
+It takes the following arguments:
+- configuration (str): The ID of the payment method configuration to update.
+- payment_method (str): The payment method type to modify (e.g., 'link').
+- enabled (bool): Whether the payment method should be enabled.
+`;
+
+export const updatePaymentMethodConfigurationParameters = (_context: Context = {}) =>
+  z.object({
+    configuration: z.string().describe('The ID of the configuration to update.'),
+    payment_method: z.string().describe('The payment method type to modify.'),
+    enabled: z.boolean().describe('Whether the payment method should be enabled.'),
+  });
+
+export const updatePaymentMethodConfiguration = async (
+  stripe: Stripe,
+  context: Context,
+  params: z.infer<ReturnType<typeof updatePaymentMethodConfigurationParameters>>
+) => {
+  try {
+    const updateParams: any = {
+      [params.payment_method]: {
+        display_preference: {merchant_enabled: params.enabled},
+      },
+    };
+
+    const config = await stripe.paymentMethodConfigurations.update(
+      params.configuration,
+      updateParams,
+      context.account ? {stripeAccount: context.account} : undefined
+    );
+
+    return {id: config.id};
+  } catch (error) {
+    return 'Failed to update payment method configuration';
+  }
+};
+
+const tool = (context: Context): Tool => ({
+  method: 'update_payment_method_configuration',
+  name: 'Update Payment Method Configuration',
+  description: updatePaymentMethodConfigurationPrompt(context),
+  parameters: updatePaymentMethodConfigurationParameters(context),
+  actions: {
+    paymentMethodConfigurations: {
+      update: true,
+    },
+  },
+  execute: updatePaymentMethodConfiguration,
+});
+
+export default tool;

--- a/typescript/src/shared/tools.ts
+++ b/typescript/src/shared/tools.ts
@@ -22,6 +22,8 @@ import updateSubscriptionTool from '@/shared/subscriptions/updateSubscription';
 import searchDocumentationTool from '@/shared/documentation/searchDocumentation';
 import listDisputesTool from '@/shared/disputes/listDisputes';
 import updateDisputeTool from '@/shared/disputes/updateDispute';
+import listPaymentMethodConfigurationsTool from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
+import updatePaymentMethodConfigurationTool from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
 
 import {Context} from './configuration';
 import Stripe from 'stripe';
@@ -57,6 +59,8 @@ const tools = (context: Context): Tool[] => [
   listSubscriptionsTool(context),
   cancelSubscriptionTool(context),
   updateSubscriptionTool(context),
+  listPaymentMethodConfigurationsTool(context),
+  updatePaymentMethodConfigurationTool(context),
   searchDocumentationTool(context),
   listCouponsTool(context),
   createCouponTool(context),

--- a/typescript/src/test/shared/paymentMethodConfigurations/functions.test.ts
+++ b/typescript/src/test/shared/paymentMethodConfigurations/functions.test.ts
@@ -1,0 +1,51 @@
+import {listPaymentMethodConfigurations} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
+import {updatePaymentMethodConfiguration} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
+
+const Stripe = jest.fn().mockImplementation(() => ({
+  paymentMethodConfigurations: {
+    list: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+
+let stripe: ReturnType<typeof Stripe>;
+
+beforeEach(() => {
+  stripe = new Stripe('fake');
+});
+
+describe('listPaymentMethodConfigurations', () => {
+  it('lists configurations', async () => {
+    const mockConfigs = {data: [{id: 'pmc_123'}]};
+    stripe.paymentMethodConfigurations.list.mockResolvedValue(mockConfigs);
+    const result = await listPaymentMethodConfigurations(stripe, {}, {});
+    expect(stripe.paymentMethodConfigurations.list).toHaveBeenCalledWith({}, undefined);
+    expect(result).toEqual(mockConfigs.data);
+  });
+
+  it('includes account if in context', async () => {
+    const mockConfigs = {data: []};
+    stripe.paymentMethodConfigurations.list.mockResolvedValue(mockConfigs);
+    const context = {account: 'acct_123'};
+    await listPaymentMethodConfigurations(stripe, context, {});
+    expect(stripe.paymentMethodConfigurations.list).toHaveBeenCalledWith({}, {stripeAccount: 'acct_123'});
+  });
+});
+
+describe('updatePaymentMethodConfiguration', () => {
+  it('updates configuration', async () => {
+    const mockConfig = {id: 'pmc_123'};
+    stripe.paymentMethodConfigurations.update.mockResolvedValue(mockConfig);
+    const result = await updatePaymentMethodConfiguration(stripe, {}, {
+      configuration: 'pmc_123',
+      payment_method: 'link',
+      enabled: true,
+    });
+    expect(stripe.paymentMethodConfigurations.update).toHaveBeenCalledWith(
+      'pmc_123',
+      {link: {display_preference: {merchant_enabled: true}}},
+      undefined
+    );
+    expect(result).toEqual({id: 'pmc_123'});
+  });
+});

--- a/typescript/src/test/shared/paymentMethodConfigurations/parameters.test.ts
+++ b/typescript/src/test/shared/paymentMethodConfigurations/parameters.test.ts
@@ -1,0 +1,20 @@
+import {listPaymentMethodConfigurationsParameters} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
+import {updatePaymentMethodConfigurationParameters} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
+
+describe('listPaymentMethodConfigurationsParameters', () => {
+  it('contains limit field', () => {
+    const params = listPaymentMethodConfigurationsParameters();
+    expect(Object.keys(params.shape)).toEqual(['limit']);
+  });
+});
+
+describe('updatePaymentMethodConfigurationParameters', () => {
+  it('contains required fields', () => {
+    const params = updatePaymentMethodConfigurationParameters();
+    expect(Object.keys(params.shape)).toEqual([
+      'configuration',
+      'payment_method',
+      'enabled',
+    ]);
+  });
+});

--- a/typescript/src/test/shared/paymentMethodConfigurations/prompts.test.ts
+++ b/typescript/src/test/shared/paymentMethodConfigurations/prompts.test.ts
@@ -1,0 +1,16 @@
+import {listPaymentMethodConfigurationsPrompt} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
+import {updatePaymentMethodConfigurationPrompt} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
+
+describe('listPaymentMethodConfigurationsPrompt', () => {
+  it('mentions limit argument', () => {
+    const prompt = listPaymentMethodConfigurationsPrompt();
+    expect(prompt).toContain('limit');
+  });
+});
+
+describe('updatePaymentMethodConfigurationPrompt', () => {
+  it('mentions configuration argument', () => {
+    const prompt = updatePaymentMethodConfigurationPrompt();
+    expect(prompt).toContain('configuration');
+  });
+});


### PR DESCRIPTION
## Summary
- support listing and updating payment method configurations
- expose the new tools in the CLI and configuration
- expand Python toolkit with payment method configuration helpers
- test new functions and prompts

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.11.0.tgz)*
- `make test` *(fails: Could not find a version that satisfies the requirement twine)*