### PR TITLE
Fix payment method config naming

### DIFF
--- a/python/stripe_agent_toolkit/configuration.py
+++ b/python/stripe_agent_toolkit/configuration.py
@@ -12,7 +12,7 @@ Object = Literal[
     "balance",
     "refunds",
     "paymentIntents",
-    "payment_method_configurations",
+    "paymentMethodConfigurations",
 ]
 
 
@@ -40,7 +40,7 @@ class Actions(TypedDict, total=False):
     refunds: Optional[Permission]
     payment_intents: Optional[Permission]
     billing_portal_sessions: Optional[Permission]
-    payment_method_configurations: Optional[Permission]
+    paymentMethodConfigurations: Optional[Permission]
 
 
 # Define Context type

--- a/python/stripe_agent_toolkit/tools.py
+++ b/python/stripe_agent_toolkit/tools.py
@@ -212,7 +212,7 @@ tools: List[Dict] = [
         "description": LIST_PAYMENT_METHOD_CONFIGURATIONS_PROMPT,
         "args_schema": ListPaymentMethodConfigurations,
         "actions": {
-            "payment_method_configurations": {
+            "paymentMethodConfigurations": {
                 "read": True,
             }
         },
@@ -223,7 +223,7 @@ tools: List[Dict] = [
         "description": UPDATE_PAYMENT_METHOD_CONFIGURATION_PROMPT,
         "args_schema": UpdatePaymentMethodConfiguration,
         "actions": {
-            "payment_method_configurations": {
+            "paymentMethodConfigurations": {
                 "update": True,
             }
         },


### PR DESCRIPTION
## Summary
- align Python action name for payment method configuration tools with the TypeScript name

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: pytest not found)*