### PR TITLE
Remove MCP CLI tool mapping

### DIFF
--- a/modelcontextprotocol/src/index.ts
+++ b/modelcontextprotocol/src/index.ts
@@ -41,8 +41,8 @@ const ACCEPTED_TOOLS = [
   'subscriptions.update',
   'disputes.read',
   'disputes.update',
-  'paymentMethodConfigurations.read',
-  'paymentMethodConfigurations.update',
+  'list_payment_method_configurations',
+  'update_payment_method_configuration',
   'documentation.read',
 ];
 


### PR DESCRIPTION
## Summary
- drop tool name mapping in the MCP CLI

## Testing
- `npm run build` in typescript *(fails: tsup not found)*
- `npm test` in typescript *(fails: jest not found)*
- `npm run build` in modelcontextprotocol *(fails to compile TypeScript)*
- `npm test` in modelcontextprotocol *(fails: jest not found)*