### PR TITLE
Fix payment method configuration tool names

### DIFF
--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -79,6 +79,8 @@ of if you're using Docker
 | `paymentIntents.read`  | Read payment intent information |
 | `subscriptions.read`   | Read subscription information   |
 | `subscriptions.update` | Update subscription information |
+| `paymentMethodConfigurations.read` | List payment method configs |
+| `paymentMethodConfigurations.update` | Update payment method config |
 | `coupons.create`       | Create a new coupon             |
 | `coupons.read`         | Read coupon information         |
 | `disputes.update`      | Update an existing dispute      |

--- a/modelcontextprotocol/src/index.ts
+++ b/modelcontextprotocol/src/index.ts
@@ -41,8 +41,8 @@ const ACCEPTED_TOOLS = [
   'subscriptions.update',
   'disputes.read',
   'disputes.update',
-  'list_payment_method_configurations',
-  'update_payment_method_configuration',
+  'paymentMethodConfigurations.read',
+  'paymentMethodConfigurations.update',
   'documentation.read',
 ];
 

--- a/python/stripe_agent_toolkit/api.py
+++ b/python/stripe_agent_toolkit/api.py
@@ -25,8 +25,8 @@ from .functions import (
     create_refund,
     list_payment_intents,
     create_billing_portal_session,
-    list_payment_method_configurations,
-    update_payment_method_configuration,
+    list_payment_method_configs,
+    update_payment_method_config,
 )
 
 
@@ -99,13 +99,13 @@ class StripeAPI(BaseModel):
             return json.dumps(
                 list_payment_intents(self._context, *args, **kwargs)
             )
-        elif method == "list_payment_method_configurations":
+        elif method == "list_payment_method_configs":
             return json.dumps(
-                list_payment_method_configurations(self._context, *args, **kwargs)
+                list_payment_method_configs(self._context, *args, **kwargs)
             )
-        elif method == "update_payment_method_configuration":
+        elif method == "update_payment_method_config":
             return json.dumps(
-                update_payment_method_configuration(self._context, *args, **kwargs)
+                update_payment_method_config(self._context, *args, **kwargs)
             )
         elif method == "create_billing_portal_session":
             return json.dumps(

--- a/python/stripe_agent_toolkit/functions.py
+++ b/python/stripe_agent_toolkit/functions.py
@@ -389,7 +389,7 @@ def create_billing_portal_session(context: Context, customer: str, return_url: O
     }
 
 
-def list_payment_method_configurations(
+def list_payment_method_configs(
     context: Context, limit: Optional[int] = None
 ):
     """List payment method configurations."""
@@ -406,7 +406,7 @@ def list_payment_method_configurations(
     return [{"id": c.id} for c in configs.data]
 
 
-def update_payment_method_configuration(
+def update_payment_method_config(
     context: Context, configuration: str, payment_method: str, enabled: bool
 ):
     """Enable or disable a payment method on a configuration."""

--- a/python/stripe_agent_toolkit/prompts.py
+++ b/python/stripe_agent_toolkit/prompts.py
@@ -113,14 +113,14 @@ It takes two arguments:
 - return_url (str, optional): The default URL to return to afterwards.
 """
 
-LIST_PAYMENT_METHOD_CONFIGURATIONS_PROMPT = """
+LIST_PAYMENT_METHOD_CONFIGS_PROMPT = """
 This tool will fetch a list of Payment Method Configurations from Stripe.
 
 It takes one optional argument:
 - limit (int, optional): The number of configurations to return.
 """
 
-UPDATE_PAYMENT_METHOD_CONFIGURATION_PROMPT = """
+UPDATE_PAYMENT_METHOD_CONFIG_PROMPT = """
 This tool will update a payment method configuration in Stripe.
 
 It takes three arguments:

--- a/python/stripe_agent_toolkit/schema.py
+++ b/python/stripe_agent_toolkit/schema.py
@@ -209,8 +209,8 @@ class CreateBillingPortalSession(BaseModel):
     )
 
 
-class ListPaymentMethodConfigurations(BaseModel):
-    """Schema for the ``list_payment_method_configurations`` operation."""
+class ListPaymentMethodConfigs(BaseModel):
+    """Schema for the ``list_payment_method_configs`` operation."""
 
     limit: Optional[int] = Field(
         None,
@@ -221,8 +221,8 @@ class ListPaymentMethodConfigurations(BaseModel):
     )
 
 
-class UpdatePaymentMethodConfiguration(BaseModel):
-    """Schema for the ``update_payment_method_configuration`` operation."""
+class UpdatePaymentMethodConfig(BaseModel):
+    """Schema for the ``update_payment_method_config`` operation."""
 
     configuration: str = Field(
         ..., description="The ID of the configuration to update."

--- a/python/stripe_agent_toolkit/tools.py
+++ b/python/stripe_agent_toolkit/tools.py
@@ -16,8 +16,8 @@ from .prompts import (
     CREATE_REFUND_PROMPT,
     LIST_PAYMENT_INTENTS_PROMPT,
     CREATE_BILLING_PORTAL_SESSION_PROMPT,
-    LIST_PAYMENT_METHOD_CONFIGURATIONS_PROMPT,
-    UPDATE_PAYMENT_METHOD_CONFIGURATION_PROMPT,
+    LIST_PAYMENT_METHOD_CONFIGS_PROMPT,
+    UPDATE_PAYMENT_METHOD_CONFIG_PROMPT,
 )
 
 from .schema import (
@@ -36,8 +36,8 @@ from .schema import (
     CreateRefund,
     ListPaymentIntents,
     CreateBillingPortalSession,
-    ListPaymentMethodConfigurations,
-    UpdatePaymentMethodConfiguration,
+    ListPaymentMethodConfigs,
+    UpdatePaymentMethodConfig,
 )
 
 tools: List[Dict] = [
@@ -207,10 +207,10 @@ tools: List[Dict] = [
         },
     },
     {
-        "method": "list_payment_method_configurations",
+        "method": "list_payment_method_configs",
         "name": "List Payment Method Configurations",
-        "description": LIST_PAYMENT_METHOD_CONFIGURATIONS_PROMPT,
-        "args_schema": ListPaymentMethodConfigurations,
+        "description": LIST_PAYMENT_METHOD_CONFIGS_PROMPT,
+        "args_schema": ListPaymentMethodConfigs,
         "actions": {
             "paymentMethodConfigurations": {
                 "read": True,
@@ -218,10 +218,10 @@ tools: List[Dict] = [
         },
     },
     {
-        "method": "update_payment_method_configuration",
+        "method": "update_payment_method_config",
         "name": "Update Payment Method Configuration",
-        "description": UPDATE_PAYMENT_METHOD_CONFIGURATION_PROMPT,
-        "args_schema": UpdatePaymentMethodConfiguration,
+        "description": UPDATE_PAYMENT_METHOD_CONFIG_PROMPT,
+        "args_schema": UpdatePaymentMethodConfig,
         "actions": {
             "paymentMethodConfigurations": {
                 "update": True,

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -17,8 +17,8 @@ from stripe_agent_toolkit.functions import (
     create_refund,
     list_payment_intents,
     create_billing_portal_session,
-    list_payment_method_configurations,
-    update_payment_method_configuration,
+    list_payment_method_configs,
+    update_payment_method_config,
 )
 
 
@@ -894,7 +894,7 @@ class TestStripeFunctions(unittest.TestCase):
                 "customer": mock_billing_portal_session["customer"],
             })
 
-    def test_list_payment_method_configurations(self):
+    def test_list_payment_method_configs(self):
         with mock.patch("stripe.PaymentMethodConfiguration.list") as mock_function:
             mock_configs = [
                 {"id": "pmc_123"},
@@ -906,17 +906,17 @@ class TestStripeFunctions(unittest.TestCase):
                 "sk"
             )
 
-            result = list_payment_method_configurations(context={})
+            result = list_payment_method_configs(context={})
 
             mock_function.assert_called_with()
             self.assertEqual(result, mock_configs)
 
-    def test_update_payment_method_configuration(self):
+    def test_update_payment_method_config(self):
         with mock.patch("stripe.PaymentMethodConfiguration.update") as mock_function:
             mock_config = {"id": "pmc_123"}
             mock_function.return_value = stripe.PaymentMethodConfiguration.construct_from(mock_config, "sk")
 
-            result = update_payment_method_configuration(
+            result = update_payment_method_config(
                 context={},
                 configuration="pmc_123",
                 payment_method="link",

--- a/typescript/src/shared/paymentMethodConfigurations/listPaymentMethodConfigs.ts
+++ b/typescript/src/shared/paymentMethodConfigurations/listPaymentMethodConfigs.ts
@@ -3,14 +3,14 @@ import {z} from 'zod';
 import type {Context} from '@/shared/configuration';
 import type {Tool} from '@/shared/tools';
 
-export const listPaymentMethodConfigurationsPrompt = (_context: Context = {}) => `
+export const listPaymentMethodConfigsPrompt = (_context: Context = {}) => `
 This tool will fetch a list of Payment Method Configurations from Stripe.
 
 It takes one optional argument:
 - limit (int, optional): The number of configurations to return.
 `;
 
-export const listPaymentMethodConfigurationsParameters = (_context: Context = {}) =>
+export const listPaymentMethodConfigsParameters = (_context: Context = {}) =>
   z.object({
     limit: z
       .number()
@@ -23,10 +23,10 @@ export const listPaymentMethodConfigurationsParameters = (_context: Context = {}
       ),
   });
 
-export const listPaymentMethodConfigurations = async (
+export const listPaymentMethodConfigs = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<ReturnType<typeof listPaymentMethodConfigurationsParameters>>
+  params: z.infer<ReturnType<typeof listPaymentMethodConfigsParameters>>
 ) => {
   try {
     const configs = await stripe.paymentMethodConfigurations.list(
@@ -41,16 +41,16 @@ export const listPaymentMethodConfigurations = async (
 };
 
 const tool = (context: Context): Tool => ({
-  method: 'list_payment_method_configurations',
-  name: 'List Payment Method Configurations',
-  description: listPaymentMethodConfigurationsPrompt(context),
-  parameters: listPaymentMethodConfigurationsParameters(context),
+  method: 'list_payment_method_configs',
+  name: 'List Payment Method Configs',
+  description: listPaymentMethodConfigsPrompt(context),
+  parameters: listPaymentMethodConfigsParameters(context),
   actions: {
     paymentMethodConfigurations: {
       read: true,
     },
   },
-  execute: listPaymentMethodConfigurations,
+  execute: listPaymentMethodConfigs,
 });
 
 export default tool;

--- a/typescript/src/shared/paymentMethodConfigurations/updatePaymentMethodConfig.ts
+++ b/typescript/src/shared/paymentMethodConfigurations/updatePaymentMethodConfig.ts
@@ -3,7 +3,7 @@ import {z} from 'zod';
 import type {Context} from '@/shared/configuration';
 import type {Tool} from '@/shared/tools';
 
-export const updatePaymentMethodConfigurationPrompt = (_context: Context = {}) => `
+export const updatePaymentMethodConfigPrompt = (_context: Context = {}) => `
 This tool will update a payment method configuration in Stripe.
 
 It takes the following arguments:
@@ -12,17 +12,17 @@ It takes the following arguments:
 - enabled (bool): Whether the payment method should be enabled.
 `;
 
-export const updatePaymentMethodConfigurationParameters = (_context: Context = {}) =>
+export const updatePaymentMethodConfigParameters = (_context: Context = {}) =>
   z.object({
     configuration: z.string().describe('The ID of the configuration to update.'),
     payment_method: z.string().describe('The payment method type to modify.'),
     enabled: z.boolean().describe('Whether the payment method should be enabled.'),
   });
 
-export const updatePaymentMethodConfiguration = async (
+export const updatePaymentMethodConfig = async (
   stripe: Stripe,
   context: Context,
-  params: z.infer<ReturnType<typeof updatePaymentMethodConfigurationParameters>>
+  params: z.infer<ReturnType<typeof updatePaymentMethodConfigParameters>>
 ) => {
   try {
     const updateParams: any = {
@@ -44,16 +44,16 @@ export const updatePaymentMethodConfiguration = async (
 };
 
 const tool = (context: Context): Tool => ({
-  method: 'update_payment_method_configuration',
-  name: 'Update Payment Method Configuration',
-  description: updatePaymentMethodConfigurationPrompt(context),
-  parameters: updatePaymentMethodConfigurationParameters(context),
+  method: 'update_payment_method_config',
+  name: 'Update Payment Method Config',
+  description: updatePaymentMethodConfigPrompt(context),
+  parameters: updatePaymentMethodConfigParameters(context),
   actions: {
     paymentMethodConfigurations: {
       update: true,
     },
   },
-  execute: updatePaymentMethodConfiguration,
+  execute: updatePaymentMethodConfig,
 });
 
 export default tool;

--- a/typescript/src/shared/tools.ts
+++ b/typescript/src/shared/tools.ts
@@ -22,8 +22,8 @@ import updateSubscriptionTool from '@/shared/subscriptions/updateSubscription';
 import searchDocumentationTool from '@/shared/documentation/searchDocumentation';
 import listDisputesTool from '@/shared/disputes/listDisputes';
 import updateDisputeTool from '@/shared/disputes/updateDispute';
-import listPaymentMethodConfigurationsTool from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
-import updatePaymentMethodConfigurationTool from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
+import listPaymentMethodConfigsTool from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigs';
+import updatePaymentMethodConfigTool from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfig';
 
 import {Context} from './configuration';
 import Stripe from 'stripe';
@@ -59,8 +59,8 @@ const tools = (context: Context): Tool[] => [
   listSubscriptionsTool(context),
   cancelSubscriptionTool(context),
   updateSubscriptionTool(context),
-  listPaymentMethodConfigurationsTool(context),
-  updatePaymentMethodConfigurationTool(context),
+  listPaymentMethodConfigsTool(context),
+  updatePaymentMethodConfigTool(context),
   searchDocumentationTool(context),
   listCouponsTool(context),
   createCouponTool(context),

--- a/typescript/src/test/shared/paymentMethodConfigurations/functions.test.ts
+++ b/typescript/src/test/shared/paymentMethodConfigurations/functions.test.ts
@@ -1,5 +1,5 @@
-import {listPaymentMethodConfigurations} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
-import {updatePaymentMethodConfiguration} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
+import {listPaymentMethodConfigs} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigs';
+import {updatePaymentMethodConfig} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfig';
 
 const Stripe = jest.fn().mockImplementation(() => ({
   paymentMethodConfigurations: {
@@ -14,11 +14,11 @@ beforeEach(() => {
   stripe = new Stripe('fake');
 });
 
-describe('listPaymentMethodConfigurations', () => {
+describe('listPaymentMethodConfigs', () => {
   it('lists configurations', async () => {
     const mockConfigs = {data: [{id: 'pmc_123'}]};
     stripe.paymentMethodConfigurations.list.mockResolvedValue(mockConfigs);
-    const result = await listPaymentMethodConfigurations(stripe, {}, {});
+    const result = await listPaymentMethodConfigs(stripe, {}, {});
     expect(stripe.paymentMethodConfigurations.list).toHaveBeenCalledWith({}, undefined);
     expect(result).toEqual(mockConfigs.data);
   });
@@ -27,16 +27,16 @@ describe('listPaymentMethodConfigurations', () => {
     const mockConfigs = {data: []};
     stripe.paymentMethodConfigurations.list.mockResolvedValue(mockConfigs);
     const context = {account: 'acct_123'};
-    await listPaymentMethodConfigurations(stripe, context, {});
+    await listPaymentMethodConfigs(stripe, context, {});
     expect(stripe.paymentMethodConfigurations.list).toHaveBeenCalledWith({}, {stripeAccount: 'acct_123'});
   });
 });
 
-describe('updatePaymentMethodConfiguration', () => {
+describe('updatePaymentMethodConfig', () => {
   it('updates configuration', async () => {
     const mockConfig = {id: 'pmc_123'};
     stripe.paymentMethodConfigurations.update.mockResolvedValue(mockConfig);
-    const result = await updatePaymentMethodConfiguration(stripe, {}, {
+    const result = await updatePaymentMethodConfig(stripe, {}, {
       configuration: 'pmc_123',
       payment_method: 'link',
       enabled: true,

--- a/typescript/src/test/shared/paymentMethodConfigurations/parameters.test.ts
+++ b/typescript/src/test/shared/paymentMethodConfigurations/parameters.test.ts
@@ -1,16 +1,16 @@
-import {listPaymentMethodConfigurationsParameters} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
-import {updatePaymentMethodConfigurationParameters} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
+import {listPaymentMethodConfigsParameters} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigs';
+import {updatePaymentMethodConfigParameters} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfig';
 
-describe('listPaymentMethodConfigurationsParameters', () => {
+describe('listPaymentMethodConfigsParameters', () => {
   it('contains limit field', () => {
-    const params = listPaymentMethodConfigurationsParameters();
+    const params = listPaymentMethodConfigsParameters();
     expect(Object.keys(params.shape)).toEqual(['limit']);
   });
 });
 
-describe('updatePaymentMethodConfigurationParameters', () => {
+describe('updatePaymentMethodConfigParameters', () => {
   it('contains required fields', () => {
-    const params = updatePaymentMethodConfigurationParameters();
+    const params = updatePaymentMethodConfigParameters();
     expect(Object.keys(params.shape)).toEqual([
       'configuration',
       'payment_method',

--- a/typescript/src/test/shared/paymentMethodConfigurations/prompts.test.ts
+++ b/typescript/src/test/shared/paymentMethodConfigurations/prompts.test.ts
@@ -1,16 +1,16 @@
-import {listPaymentMethodConfigurationsPrompt} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigurations';
-import {updatePaymentMethodConfigurationPrompt} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfiguration';
+import {listPaymentMethodConfigsPrompt} from '@/shared/paymentMethodConfigurations/listPaymentMethodConfigs';
+import {updatePaymentMethodConfigPrompt} from '@/shared/paymentMethodConfigurations/updatePaymentMethodConfig';
 
-describe('listPaymentMethodConfigurationsPrompt', () => {
+describe('listPaymentMethodConfigsPrompt', () => {
   it('mentions limit argument', () => {
-    const prompt = listPaymentMethodConfigurationsPrompt();
+    const prompt = listPaymentMethodConfigsPrompt();
     expect(prompt).toContain('limit');
   });
 });
 
-describe('updatePaymentMethodConfigurationPrompt', () => {
+describe('updatePaymentMethodConfigPrompt', () => {
   it('mentions configuration argument', () => {
-    const prompt = updatePaymentMethodConfigurationPrompt();
+    const prompt = updatePaymentMethodConfigPrompt();
     expect(prompt).toContain('configuration');
   });
 });


### PR DESCRIPTION
## Summary
- rename payment method configuration utilities to shorter snake_case names
- update tools list for model context protocol
- adjust docs and tests for new names

## Testing
- `make test` *(fails: Could not install twine)*
- `pnpm run test` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*